### PR TITLE
Wait for readyness on populate

### DIFF
--- a/docs/03_Filling_collections.md
+++ b/docs/03_Filling_collections.md
@@ -7,3 +7,7 @@ bin/console biblioverse:typesense:populate
 
 This will populate your collection with all the entities from your configuration.
 If you only want to populate the mapping without data, use the `--no-data` option.
+
+The command will wait for the Typesense server and the database to be ready before starting the population.
+
+It will try to check the connectivity every second for `--nb-retry` times.

--- a/src/Command/TypesensePopulateCommand.php
+++ b/src/Command/TypesensePopulateCommand.php
@@ -71,6 +71,9 @@ class TypesensePopulateCommand extends Command
         return Command::SUCCESS;
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     private function fillCollection(SymfonyStyle $symfonyStyle, string $longName, DataGeneratorInterface $dataGenerator, OutputInterface $output): void
     {
         $progressBar = new ProgressBar($output, 0);
@@ -86,6 +89,7 @@ class TypesensePopulateCommand extends Command
         } catch (\Exception $e) {
             $symfonyStyle->error($e->getMessage());
             $this->populateService->deleteCollection($longName);
+            throw new \RuntimeException('Error while populating collection '.$longName, 0, $e);
         } finally {
             $progressBar->clear();
         }

--- a/src/Populate/WaitFor/AbstractWaitForService.php
+++ b/src/Populate/WaitFor/AbstractWaitForService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Populate\WaitFor;
+
+abstract class AbstractWaitForService implements WaitForInterface
+{
+    public function wait(int $maxSteps, ?callable $callable = null, int $sleepInSeconds = 1): void
+    {
+        if ($maxSteps < 1) {
+            return;
+        }
+
+        $step = 1;
+        do {
+            try {
+                $this->doCheck();
+
+                return;
+            } catch (\Throwable $e) {
+                $lastException = $e;
+                if (is_callable($callable)) {
+                    $callable($step, $maxSteps, $e);
+                }
+                sleep($sleepInSeconds);
+            }
+        } while ($step++ < $maxSteps);
+
+        throw new \RuntimeException(sprintf('%s is not available', $this->getName()), 0, $lastException);
+    }
+
+    abstract public function getName(): string;
+
+    /**
+     * @throws \Exception
+     */
+    abstract public function doCheck(): void;
+}

--- a/src/Populate/WaitFor/WaitForDatabaseService.php
+++ b/src/Populate/WaitFor/WaitForDatabaseService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Populate\WaitFor;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class WaitForDatabaseService extends AbstractWaitForService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'Database';
+    }
+
+    public function doCheck(): void
+    {
+        $connection = $this->entityManager->getConnection();
+        if ($connection->isConnected()) {
+            return;
+        }
+        $connection->executeQuery('SELECT 1');
+    }
+}

--- a/src/Populate/WaitFor/WaitForInterface.php
+++ b/src/Populate/WaitFor/WaitForInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Populate\WaitFor;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(WaitForInterface::TAG_NAME)]
+interface WaitForInterface
+{
+    public const TAG_NAME = 'typesensebundle.wait_for_service';
+
+    /**
+     * @param ?callable(int $step, int $maxSteps,\Throwable $exception):void $callable Callback on each failed step
+     *
+     * @throws \RuntimeException
+     */
+    public function wait(int $maxSteps, ?callable $callable = null, int $sleepInSeconds = 1): void;
+
+    public function getName(): string;
+}

--- a/src/Populate/WaitFor/WaitForTypesenseService.php
+++ b/src/Populate/WaitFor/WaitForTypesenseService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Populate\WaitFor;
+
+use Biblioverse\TypesenseBundle\Client\ClientInterface;
+
+class WaitForTypesenseService extends AbstractWaitForService
+{
+    public function __construct(
+        private readonly ClientInterface $client,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'Typesense';
+    }
+
+    public function doCheck(): void
+    {
+        $health = $this->client->getHealth()->retrieve();
+        if ($health !== ['ok' => true]) {
+            throw new \Exception('Typesense is not healthy');
+        }
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -40,6 +40,10 @@ services:
     resource: '../../Command/'
     tags: ['console.command']
 
+  Biblioverse\TypesenseBundle\Populate\WaitFor\:
+    resource: '../../Populate/WaitFor/'
+    tags: [!php/const Biblioverse\TypesenseBundle\Populate\WaitFor\WaitForInterface::TAG_NAME]
+
   biblioverse_typesense.collection.abstract:
     class: Biblioverse\TypesenseBundle\Search\SearchCollection
     abstract: true

--- a/tests/Command/TypesensePopulateCommandTest.php
+++ b/tests/Command/TypesensePopulateCommandTest.php
@@ -9,9 +9,10 @@ use Biblioverse\TypesenseBundle\Mapper\DataGeneratorInterface;
 use Biblioverse\TypesenseBundle\Mapper\Entity\EntityTransformerInterface;
 use Biblioverse\TypesenseBundle\Mapper\Locator\MapperLocatorInterface;
 use Biblioverse\TypesenseBundle\Populate\PopulateService;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class TypesensePopulateCommandTest extends \PHPUnit\Framework\TestCase
+class TypesensePopulateCommandTest extends TestCase
 {
     public function testEmpty(): void
     {
@@ -38,5 +39,34 @@ class TypesensePopulateCommandTest extends \PHPUnit\Framework\TestCase
 
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('Creating collection', $output);
+    }
+
+    public function testNoAlias(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Error while populating collection');
+
+        $mapper = $this->createMock(MapperLocatorInterface::class);
+        $mapper->method('countDataGenerator')->willReturn(1);
+        $mapper->method('getDataGenerator')->willReturn($this->createMock(DataGeneratorInterface::class));
+        $mapper->method('getEntityTransformers')->willReturnCallback(fn () => ['mapper' => $this->createMock(EntityTransformerInterface::class)]);
+        $mapper->method('getMappers')->willReturnCallback(fn () => ['mapper' => $this->createMock(CollectionManagerInterface::class)]);
+
+        $populate = $this->createMock(PopulateService::class);
+        $populate->method('fillCollection')->willThrowException(new \RuntimeException('Error while populating collection'));
+
+        $typesensePopulateCommand = new TypesensePopulateCommand($populate, $mapper, $this->createMock(CollectionAliasInterface::class));
+
+        $commandTester = null;
+        try {
+            $commandTester = new CommandTester($typesensePopulateCommand);
+            $code = $commandTester->execute([]);
+        } finally {
+            $output = $commandTester?->getDisplay() ?? '';
+            $this->assertStringContainsString('Error while populating collection', $output);
+            $this->assertStringNotContainsString('Aliasing collection', $output);
+        }
+
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Command/TypesensePopulateCommandTest.php
+++ b/tests/Command/TypesensePopulateCommandTest.php
@@ -9,6 +9,7 @@ use Biblioverse\TypesenseBundle\Mapper\DataGeneratorInterface;
 use Biblioverse\TypesenseBundle\Mapper\Entity\EntityTransformerInterface;
 use Biblioverse\TypesenseBundle\Mapper\Locator\MapperLocatorInterface;
 use Biblioverse\TypesenseBundle\Populate\PopulateService;
+use Biblioverse\TypesenseBundle\Populate\WaitFor\AbstractWaitForService;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -67,6 +68,78 @@ class TypesensePopulateCommandTest extends TestCase
             $this->assertStringNotContainsString('Aliasing collection', $output);
         }
 
+        $this->assertSame(0, $code);
+    }
+
+    public function testNoData(): void
+    {
+        $mapper = $this->createMock(MapperLocatorInterface::class);
+        $mapper->method('countDataGenerator')->willReturn(1);
+        $mapper->expects($this->never())->method('getDataGenerator')->willThrowException(new \RuntimeException('Should not be called'));
+        $mapper->expects($this->never())->method('getEntityTransformers')->willReturnCallback(fn () => ['mapper' => $this->createMock(EntityTransformerInterface::class)]);
+        $mapper->method('getMappers')->willReturnCallback(fn () => ['mapper' => $this->createMock(CollectionManagerInterface::class)]);
+        $typesensePopulateCommand = new TypesensePopulateCommand($this->createMock(PopulateService::class), $mapper, $this->createMock(CollectionAliasInterface::class));
+        $commandTester = new CommandTester($typesensePopulateCommand);
+        $code = $commandTester->execute(['--no-data' => true]);
+        $this->assertSame(0, $code);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Creating collection', $output);
+    }
+
+    public function testNoTries(): void
+    {
+        $dummyWaitForService = new class extends AbstractWaitForService {
+            public function getName(): string
+            {
+                return 'dummy';
+            }
+
+            public function doCheck(): void
+            {
+                throw new \LogicException('Should not be called');
+            }
+        };
+        $mapper = $this->createMock(MapperLocatorInterface::class);
+        $mapper->method('countDataGenerator')->willReturn(1);
+        $mapper->method('getDataGenerator')->willReturn($this->createMock(DataGeneratorInterface::class));
+        $mapper->method('getEntityTransformers')->willReturnCallback(fn () => ['mapper' => $this->createMock(EntityTransformerInterface::class)]);
+        $mapper->method('getMappers')->willReturnCallback(fn () => ['mapper' => $this->createMock(CollectionManagerInterface::class)]);
+        $typesensePopulateCommand = new TypesensePopulateCommand($this->createMock(PopulateService::class), $mapper, $this->createMock(CollectionAliasInterface::class), [$dummyWaitForService]);
+        $commandTester = new CommandTester($typesensePopulateCommand);
+        $code = $commandTester->execute(['--nb-retry' => 0]);
+        $this->assertSame(0, $code);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Creating collection', $output);
+    }
+
+    public function testTryingOutput(): void
+    {
+        $dummyWaitForService = new class extends AbstractWaitForService {
+            public function getName(): string
+            {
+                return 'Dummy';
+            }
+
+            public function doCheck(): void
+            {
+                static $onlyOnce = null;
+                if ($onlyOnce === null) {
+                    $onlyOnce = true;
+                    throw new \RuntimeException('This is an error');
+                }
+            }
+        };
+        $mapper = $this->createMock(MapperLocatorInterface::class);
+        $mapper->method('countDataGenerator')->willReturn(1);
+        $mapper->method('getDataGenerator')->willReturn($this->createMock(DataGeneratorInterface::class));
+        $mapper->method('getEntityTransformers')->willReturnCallback(fn () => ['mapper' => $this->createMock(EntityTransformerInterface::class)]);
+        $mapper->method('getMappers')->willReturnCallback(fn () => ['mapper' => $this->createMock(CollectionManagerInterface::class)]);
+
+        $typesensePopulateCommand = new TypesensePopulateCommand($this->createMock(PopulateService::class), $mapper, $this->createMock(CollectionAliasInterface::class), [$dummyWaitForService]);
+        $commandTester = new CommandTester($typesensePopulateCommand);
+        $code = $commandTester->execute(['--nb-retry' => 2]);
         $this->assertSame(0, $code);
     }
 }

--- a/tests/Populate/WaitFor/WaitForDatabaseServiceTest.php
+++ b/tests/Populate/WaitFor/WaitForDatabaseServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Tests\Populate\WaitFor;
+
+use Biblioverse\TypesenseBundle\Populate\WaitFor\WaitForDatabaseService;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\InvalidArgumentException as DBALException;
+use Doctrine\DBAL\Result;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class WaitForDatabaseServiceTest extends TestCase
+{
+    public function testWaitReturnsImmediatelyIfConnected(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(true);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $waitForDatabaseService = new WaitForDatabaseService($entityManager);
+
+        $callbackCalls = [];
+        $callback = function (int $step, int $total, \Throwable $throwable) use (&$callbackCalls) {
+            $callbackCalls[] = [$step, $total, $throwable];
+        };
+
+        $waitForDatabaseService->wait(5, $callback, 0);
+        $this->assertCount(0, $callbackCalls);
+    }
+
+    public function testWaitRetriesUntilConnected(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(false);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $waitForDatabaseService = new WaitForDatabaseService($entityManager);
+
+        // Simulate failure twice before succeeding
+        $attempts = 0;
+        $connection->method('executeQuery')->willReturnCallback(function () use (&$attempts) {
+            if ($attempts < 2) {
+                ++$attempts;
+                throw new DBALException('Internal error');
+            }
+
+            return $this->createMock(Result::class);
+        });
+
+        $waitForDatabaseService->wait(5, null, 0); // No sleep for faster test execution
+        $this->assertEquals(2, $attempts);
+    }
+
+    public function testWaitThrowsExceptionAfterMaxAttempts(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(false);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $waitForDatabaseService = new WaitForDatabaseService($entityManager);
+
+        $connection->method('executeQuery')->willThrowException(new DBALException('Internal error'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Database is not available');
+
+        $waitForDatabaseService->wait(3, null, 0);
+    }
+
+    public function testWaitCallsCallbackOnFailure(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(false);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $waitForDatabaseService = new WaitForDatabaseService($entityManager);
+
+        $attempts = 0;
+        $connection->method('executeQuery')->willReturnCallback(function () use (&$attempts) {
+            ++$attempts;
+            throw new DBALException('Internal error');
+        });
+
+        $callbackCalls = [];
+        $callback = function ($step, $total, $exception) use (&$callbackCalls) {
+            $callbackCalls[] = [$step, $total, $exception];
+        };
+
+        try {
+            $waitForDatabaseService->wait(3, $callback, 0);
+            $this->fail('Expected exception for waiting too many times');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Database is not available', $e->getMessage());
+        }
+
+        $this->assertCount(3, $callbackCalls);
+        $i = 1;
+        foreach ($callbackCalls as [$step, $total, $exception]) {
+            $this->assertEquals($i++, $step, 'step number is not valid');
+            $this->assertEquals(3, $total, 'total number is not valid');
+            $this->assertInstanceOf(\Throwable::class, $exception);
+        }
+    }
+}

--- a/tests/Populate/WaitFor/WaitForTypesenseServiceTest.php
+++ b/tests/Populate/WaitFor/WaitForTypesenseServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Tests\Populate\WaitFor;
+
+use Biblioverse\TypesenseBundle\Client\ClientInterface;
+use Biblioverse\TypesenseBundle\Populate\WaitFor\WaitForTypesenseService;
+use PHPUnit\Framework\TestCase;
+use Typesense\Health as HealthInterface;
+
+class WaitForTypesenseServiceTest extends TestCase
+{
+    public function testWaitSucceedsImmediately(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $health = $this->createMock(HealthInterface::class);
+        $health->method('retrieve')->willReturn(['ok' => true]);
+
+        $client->method('getHealth')->willReturn($health);
+
+        $waitForTypesenseService = new WaitForTypesenseService($client);
+
+        $this->expectNotToPerformAssertions();
+        $waitForTypesenseService->wait(3, null, 0);
+    }
+
+    public function testWaitRetriesAndSucceeds(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $health = $this->createMock(HealthInterface::class);
+        $health->method('retrieve')->willReturn(['ok' => true]);
+
+        $client->method('getHealth')->willReturn($health);
+
+        $callCount = 0;
+        $health->method('retrieve')->willReturnCallback(function () use (&$callCount) {
+            if ($callCount++ === 0) {
+                throw new \Exception('Service unavailable');
+            }
+
+            return true;
+        });
+
+        $waitForTypesenseService = new WaitForTypesenseService($client);
+
+        $this->expectNotToPerformAssertions();
+        $waitForTypesenseService->wait(3, null, 0);
+    }
+
+    public function testWaitThrowsExceptionOnUnHealthy(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $health = $this->createMock(HealthInterface::class);
+        $health->method('retrieve')->willReturn(['ok' => false]);
+        $client->method('getHealth')->willReturn($health);
+
+        $waitForTypesenseService = new WaitForTypesenseService($client);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Typesense is not available');
+
+        $waitForTypesenseService->wait(3, null, 0);
+    }
+
+    public function testWaitThrowsExceptionAfterMaxRetries(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $health = $this->createMock(HealthInterface::class);
+
+        $client->method('getHealth')->willReturn($health);
+
+        $health->method('retrieve')
+            ->willThrowException(new \Exception('Service unavailable'));
+
+        $waitForTypesenseService = new WaitForTypesenseService($client);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Typesense is not available');
+
+        $waitForTypesenseService->wait(3, null, 0);
+    }
+
+    public function testGetNameReturnsTypesense(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $waitForTypesenseService = new WaitForTypesenseService($client);
+
+        $this->assertEquals('Typesense', $waitForTypesenseService->getName());
+    }
+}


### PR DESCRIPTION
Fixes for https://github.com/biblioverse/TypesenseBundle/issues/52

# Todo
- [x] Tests for `WaitForTypesenseService`
- [x] Test for real (not with unit tests)
- [x] Test don't alias on failure
- [x] `getServerVersion` is not always public.