### PR TITLE
feat(multisearch): Multisearch with union search support

### DIFF
--- a/src/CollectionAlias/CollectionAlias.php
+++ b/src/CollectionAlias/CollectionAlias.php
@@ -56,4 +56,19 @@ class CollectionAlias implements CollectionAliasInterface
             return false;
         }
     }
+
+    public function revertName(string $name): string
+    {
+        // Remove the timestamp suffix (format: -Y-m-d-H-i-s)
+        $nameWithoutTimestamp = preg_replace('/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/', '', $name) ?? throw new AliasException("Unable to revert name '$name'.");
+
+        // Remove the collection template prefix/suffix
+        $pattern = str_replace('%s', '(.+)', preg_quote($this->collectionTemplate, '/'));
+
+        if (preg_match('/^'.$pattern.'$/', $nameWithoutTimestamp, $matches)) {
+            return $matches[1];
+        }
+
+        throw new AliasException("Unable to revert name '$name' with template '{$this->collectionTemplate}'.");
+    }
 }

--- a/src/CollectionAlias/CollectionAliasInterface.php
+++ b/src/CollectionAlias/CollectionAliasInterface.php
@@ -6,5 +6,7 @@ interface CollectionAliasInterface
 {
     public function getName(string $name): string;
 
+    public function revertName(string $name): string;
+
     public function switch(string $shortName, string $longName): void;
 }

--- a/src/Query/SearchQueryWithCollectionInterface.php
+++ b/src/Query/SearchQueryWithCollectionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Query;
+
+interface SearchQueryWithCollectionInterface extends SearchQueryInterface
+{
+    public function getCollection(): string;
+}

--- a/src/Query/SearchQueryWithWithCollectionAdapter.php
+++ b/src/Query/SearchQueryWithWithCollectionAdapter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Query;
+
+class SearchQueryWithWithCollectionAdapter implements SearchQueryWithCollectionInterface
+{
+    public function __construct(private readonly SearchQueryInterface $searchQuery, private readonly string $collectionName)
+    {
+    }
+
+    public function getCollection(): string
+    {
+        return $this->collectionName;
+    }
+
+    public function toArray(): array
+    {
+        return $this->searchQuery->toArray();
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -82,3 +82,9 @@ services:
       $enabled: '%biblioverse_typesense.config.auto_update%'
     tags:
       - { name: doctrine.event_subscriber, connection: default }
+
+
+  Biblioverse\TypesenseBundle\Search\Hydrate\HydrateUnion:
+    autowire: true
+    arguments:
+      $entityMapping: '%biblioverse_typesense.config.entity_mapping%'

--- a/src/Search/Hydrate/HydrateSearchResult.php
+++ b/src/Search/Hydrate/HydrateSearchResult.php
@@ -6,6 +6,7 @@ use Biblioverse\TypesenseBundle\Search\Results\SearchResults;
 use Biblioverse\TypesenseBundle\Search\Results\SearchResultsHydrated;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * @template T of object
@@ -14,7 +15,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 class HydrateSearchResult implements HydrateSearchResultInterface
 {
-    public function __construct(private readonly EntityManagerInterface $entityManager)
+    public function __construct(private readonly EntityManagerInterface $entityManager, private readonly PropertyAccessorInterface $propertyAccessor)
     {
     }
 
@@ -87,5 +88,25 @@ class HydrateSearchResult implements HydrateSearchResultInterface
         }
 
         return $identifiers[0];
+    }
+
+    public function getId(object $object): string
+    {
+        $classMetadata = $this->entityManager->getClassMetadata($object::class);
+        if ($classMetadata->isIdentifierComposite) {
+            throw new \RuntimeException(sprintf('Composite identifier not supported to be hydrated for class: %s', $classMetadata->getName()));
+        }
+        $idField = $this->getIdNameFromMetadata($classMetadata);
+
+        $value = $this->propertyAccessor->getValue($object, $idField);
+        if ($value === null) {
+            throw new \RuntimeException(sprintf('Unable to read identifier field for class %s: Value is null', $classMetadata->getName()));
+        }
+
+        if (false === is_scalar($value)) {
+            throw new \RuntimeException(sprintf('Unable to read identifier field for class %s: Value is not scalar', $classMetadata->getName()));
+        }
+
+        return (string) $value;
     }
 }

--- a/src/Search/Hydrate/HydrateSearchResultInterface.php
+++ b/src/Search/Hydrate/HydrateSearchResultInterface.php
@@ -16,4 +16,6 @@ interface HydrateSearchResultInterface
      * @return SearchResultsHydrated<T>
      */
     public function hydrate(string $class, SearchResults $searchResults): SearchResultsHydrated;
+
+    public function getId(object $object): string;
 }

--- a/src/Search/Hydrate/HydrateUnion.php
+++ b/src/Search/Hydrate/HydrateUnion.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Search\Hydrate;
+
+use Biblioverse\TypesenseBundle\CollectionAlias\CollectionAliasInterface;
+use Biblioverse\TypesenseBundle\Search\Results\AbstractSearchResults;
+use Biblioverse\TypesenseBundle\Search\Results\SearchResults;
+use Biblioverse\TypesenseBundle\Search\Results\SearchResultsHydrated;
+
+/**
+ * @phpstan-import-type Hit from AbstractSearchResults
+ */
+class HydrateUnion
+{
+    public function __construct(
+        private readonly CollectionAliasInterface $collectionAlias,
+        /** @var HydrateSearchResultInterface<object> */
+        private readonly HydrateSearchResultInterface $hydrateSearchResult,
+        /** @var array<class-string, array<int, string>> Map of Entity class and collections */
+        private readonly array $entityMapping,
+    ) {
+    }
+
+    /**
+     * @return SearchResultsHydrated<object>
+     */
+    public function hydrate(SearchResults $searchResults): SearchResultsHydrated
+    {
+        if ($searchResults->getUnionRequestParameters() === null) {
+            throw new \LogicException('Union request parameters not set');
+        }
+
+        $hitsByCollection = [];
+        foreach ($searchResults->getHits() as $hit) {
+            $collection = $this->getCollectionFromHit($hit);
+            $hitsByCollection[$collection][] = $hit;
+        }
+
+        $hydratedByCollectionAndIds = [];
+        foreach ($hitsByCollection as $collection => $hits) {
+            $hydratedByCollectionAndIds[$collection] = $this->hydrateHitsById($collection, $hits);
+        }
+
+        $hydratedResults = [];
+        foreach ($searchResults->getHits() as $hit) {
+            $collection = $this->getCollectionFromHit($hit);
+            $id = $hit['document']['id'] ?? null;
+            if ($id === null || false === is_scalar($id)) {
+                throw new \RuntimeException('One hit has no identifier: '.json_encode($hit, \JSON_THROW_ON_ERROR));
+            }
+            $id = (string) $id;
+            if (false === array_key_exists($id, $hydratedByCollectionAndIds[$collection])) {
+                // Skip Hits not in database
+                continue;
+            }
+            $hydratedResults[$collection.'_'.$id] = $hydratedByCollectionAndIds[$collection][$id];
+        }
+
+        return SearchResultsHydrated::fromResultAndCollection($searchResults, $hydratedResults);
+    }
+
+    /**
+     * @param Hit $hit
+     */
+    private function getCollectionFromHit(array $hit): string
+    {
+        $collection = $hit['collection'] ?? throw new \LogicException('You hit has no collection, which is not normal for union search');
+
+        return $this->removeCollectionAlias($collection);
+    }
+
+    private function removeCollectionAlias(string $collection): string
+    {
+        return $this->collectionAlias->revertName($collection);
+    }
+
+    /**
+     * @param array<Hit> $hits
+     *
+     * @return array<string,object> Object indexed by ids (as string)
+     */
+    private function hydrateHitsById(string $collection, array $hits): array
+    {
+        foreach ($this->entityMapping as $class => $mapped_collection) {
+            if (false === in_array($collection, $mapped_collection)) {
+                continue;
+            }
+            $results = $this->hydrateSearchResult->hydrate($class, new SearchResults([
+                'hits' => $hits,
+            ]))->getResults();
+            $response = [];
+            foreach ($results as $result) {
+                $response[$this->hydrateSearchResult->getId($result)] = $result;
+            }
+
+            return $response;
+        }
+        throw new \RuntimeException(sprintf('Collection %s is not supported to be hydrated', $collection));
+    }
+}

--- a/src/Search/Results/SearchResults.php
+++ b/src/Search/Results/SearchResults.php
@@ -12,11 +12,11 @@ class SearchResults extends AbstractSearchResults
     public function getIterator(): \Traversable
     {
         $data = [];
-        if ($this->offsetExists('hits') && is_array($this->data['hits'])) {
+        if (is_array($this->data['hits']) && $this->offsetExists('hits')) {
             $data = $this->data['hits'];
         }
         /** @var array<int, array<string, mixed>> $data */
-        $data = array_filter(array_map(function (mixed $hits): mixed {
+        $data = array_filter(array_map(static function (mixed $hits): mixed {
             if (!is_array($hits) || $hits === [] || !isset($hits['document'])) {
                 return null;
             }

--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -4,7 +4,8 @@ namespace Biblioverse\TypesenseBundle\Search;
 
 use Biblioverse\TypesenseBundle\Client\ClientInterface;
 use Biblioverse\TypesenseBundle\Exception\SearchException;
-use Biblioverse\TypesenseBundle\Query\SearchQuery;
+use Biblioverse\TypesenseBundle\Query\SearchQueryInterface;
+use Biblioverse\TypesenseBundle\Query\SearchQueryWithCollectionInterface;
 use Biblioverse\TypesenseBundle\Search\Results\SearchResults;
 use Http\Client\Exception;
 use Typesense\Exceptions\TypesenseClientError;
@@ -18,7 +19,7 @@ class Search implements SearchInterface
     /**
      * @throws SearchException
      */
-    public function search(string $collectionName, SearchQuery $searchQuery): SearchResults
+    public function search(string $collectionName, SearchQueryInterface $searchQuery): SearchResults
     {
         try {
             /** @var array<string, mixed> $result */
@@ -29,5 +30,49 @@ class Search implements SearchInterface
         } catch (TypesenseClientError|Exception $e) {
             throw new SearchException($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    /**
+     * @param SearchQueryWithCollectionInterface[] $searchQueries
+     * @param array<string, mixed>                 $queryParameters
+     *
+     * @return SearchResults[]
+     */
+    public function multiSearch(array $searchQueries, array $queryParameters = []): array
+    {
+        $rawSearchQueries = array_map(fn (SearchQueryWithCollectionInterface $searchQueryWithCollection) => ['collection' => $searchQueryWithCollection->getCollection()] + $searchQueryWithCollection->toArray(), $searchQueries);
+        try {
+            /** @var array{'results'?: array<string, mixed>} $rawResult * */
+            $rawResult = $this->client->getMultiSearch()
+                ->perform(['searches' => $rawSearchQueries], $queryParameters);
+
+            $results = $rawResult['results'] ?? [];
+            $response = [];
+            /**
+             * @var int                 $index
+             * @var array<string,mixed> $result
+             */
+            foreach ($results as $index => $result) {
+                if (isset($result['error']) && isset($result['code'])) {
+                    $this->throwMultiSearchException($index, $result);
+                }
+                $response[] = new SearchResults($result);
+            }
+
+            return $response;
+        } catch (TypesenseClientError|Exception $e) {
+            throw new SearchException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function throwMultiSearchException(int $index, array $result): void
+    {
+        $code = is_resource($result['code']) || !is_int($result['code']) ? 0 : $result['code'];
+        $error = is_resource($result['error']) || !is_string($result['error']) ? 'Error' : $result['error'];
+
+        throw new SearchException(sprintf('Multi-search sub-result error at %d: %s %s', $index, $code, $error));
     }
 }

--- a/src/Search/SearchCollectionInterface.php
+++ b/src/Search/SearchCollectionInterface.php
@@ -4,6 +4,7 @@ namespace Biblioverse\TypesenseBundle\Search;
 
 use Biblioverse\TypesenseBundle\Exception\SearchException;
 use Biblioverse\TypesenseBundle\Query\SearchQuery;
+use Biblioverse\TypesenseBundle\Query\SearchQueryInterface;
 use Biblioverse\TypesenseBundle\Search\Results\SearchResults;
 use Biblioverse\TypesenseBundle\Search\Results\SearchResultsHydrated;
 
@@ -19,5 +20,19 @@ interface SearchCollectionInterface
      */
     public function search(SearchQuery $searchQuery): SearchResultsHydrated;
 
+    /**
+     * @param SearchQueryInterface[] $searchQueries
+     *
+     * @return list<SearchResultsHydrated<T>>
+     */
+    public function multisearch(array $searchQueries): array;
+
     public function searchRaw(SearchQuery $searchQuery): SearchResults;
+
+    /**
+     * @param SearchQueryInterface[] $searchQueries é
+     *
+     * @return SearchResults[]
+     */
+    public function multisearchRaw(array $searchQueries): array;
 }

--- a/src/Search/SearchInterface.php
+++ b/src/Search/SearchInterface.php
@@ -4,6 +4,7 @@ namespace Biblioverse\TypesenseBundle\Search;
 
 use Biblioverse\TypesenseBundle\Exception\SearchException;
 use Biblioverse\TypesenseBundle\Query\SearchQuery;
+use Biblioverse\TypesenseBundle\Query\SearchQueryWithCollectionInterface;
 use Biblioverse\TypesenseBundle\Search\Results\SearchResults;
 
 interface SearchInterface
@@ -12,4 +13,12 @@ interface SearchInterface
      * @throws SearchException
      */
     public function search(string $collectionName, SearchQuery $searchQuery): SearchResults;
+
+    /**
+     * @param SearchQueryWithCollectionInterface[] $searchQueries
+     * @param array<string, mixed>                 $queryParameters
+     *
+     * @return SearchResults[]
+     */
+    public function multiSearch(array $searchQueries, array $queryParameters = []): array;
 }

--- a/tests/CollectionAlias/CollectionAliasTest.php
+++ b/tests/CollectionAlias/CollectionAliasTest.php
@@ -24,6 +24,9 @@ class CollectionAliasTest extends TestCase
 
         // Date is injected
         $this->assertStringStartsWith('pre-books-suffix-'.date('Y'), $collectionAlias->getName('books'));
+
+        // Revert works
+        $this->assertSame('books', $collectionAlias->revertName('pre-books-suffix-'.date('Y-m-d-H-i-s')));
     }
 
     public function testSwitch(): void

--- a/tests/Query/SearchQueryWithCollectionAdapterTest.php
+++ b/tests/Query/SearchQueryWithCollectionAdapterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Tests\Query;
+
+use Biblioverse\TypesenseBundle\Query\SearchQueryInterface;
+use Biblioverse\TypesenseBundle\Query\SearchQueryWithWithCollectionAdapter;
+use PHPUnit\Framework\TestCase;
+
+class SearchQueryWithCollectionAdapterTest extends TestCase
+{
+    public function testAdapter(): void
+    {
+        $query = new class implements SearchQueryInterface {
+            public function toArray(): array
+            {
+                return ['q' => '12'];
+            }
+        };
+
+        $searchQueryWithWithCollectionAdapter = new SearchQueryWithWithCollectionAdapter($query, 'def');
+        $this->assertSame('def', $searchQueryWithWithCollectionAdapter->getCollection());
+        $this->assertSame(['q' => '12'], $searchQueryWithWithCollectionAdapter->toArray());
+    }
+}

--- a/tests/Query/SearchTest.php
+++ b/tests/Query/SearchTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Biblioverse\TypesenseBundle\Tests\Query;
+
+use Biblioverse\TypesenseBundle\Client\ClientInterface;
+use Biblioverse\TypesenseBundle\Query\SearchQuery;
+use Biblioverse\TypesenseBundle\Query\SearchQueryWithWithCollectionAdapter;
+use Biblioverse\TypesenseBundle\Search\Results\SearchResults;
+use Biblioverse\TypesenseBundle\Search\Search;
+use PHPUnit\Framework\TestCase;
+use Typesense\ApiCall;
+use Typesense\Collection;
+use Typesense\Documents;
+use Typesense\MultiSearch;
+
+class SearchTest extends TestCase
+{
+    /**
+     * @param array<string,mixed> $result
+     *
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    private function withSearchResult(string $collectionName, array $result): ClientInterface
+    {
+        $docs = $this->createMock(Documents::class);
+        $docs->expects($this->once())->method('search')->willReturn($result);
+
+        $collection = new Collection('collection', $this->createMock(ApiCall::class));
+        $collection->documents = $docs;
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('getCollection')->with($collectionName)->willReturn($collection);
+
+        return $client;
+    }
+
+    /**
+     * @param array<string,mixed> $result
+     */
+    private function withMultiSearchResult(array $result): ClientInterface
+    {
+        $multiSearch = $this->createMock(MultiSearch::class);
+        $multiSearch->expects($this->any())->method('perform')->willReturn($result);
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('getMultiSearch')->willReturn($multiSearch);
+
+        return $client;
+    }
+
+    public function testEmptySearch(): void
+    {
+        $client = $this->withSearchResult('mycollection', []);
+
+        $search = new Search($client);
+        $searchResults = $search->search('mycollection', new SearchQuery(q: 'test', queryBy: 'name'));
+
+        $this->assertCount(0, $searchResults->getResults());
+    }
+
+    public function testOneResultSearch(): void
+    {
+        $client = $this->withSearchResult('mybooks', [
+            'found' => 1,
+            'hits' => [
+                0 => [
+                    'document' => [
+                        'id' => '117',
+                        'title' => 'My Book title',
+                        'updated' => 1738617395,
+                        'verified' => true,
+                    ],
+                ],
+            ],
+            'out_of' => 42,
+            'page' => 1,
+            'request_params' => [
+                'collection_name' => 'mybooks',
+                'first_q' => 'book',
+                'per_page' => 200,
+                'q' => 'book',
+            ],
+            'search_cutoff' => false,
+            'search_time_ms' => 6,
+        ]);
+
+        $search = new Search($client);
+        $searchResults = $search->search('mybooks', new SearchQuery(q: 'test', queryBy: 'name'));
+
+        $this->assertCount(1, $searchResults->getResults());
+        $this->assertSame('My Book title', $searchResults->getResults()[0]['title']);
+    }
+
+    public function testMultiSearch(): void
+    {
+        $client = $this->withMultiSearchResult([
+            'results' => [
+                0 => [
+                    'found' => 1,
+                    'hits' => [
+                        0 => [
+                            'document' => [
+                                'id' => '117',
+                                'title' => 'Book title',
+                            ],
+                            'highlight' => [
+                                'title' => [
+                                    'matched_tokens' => [
+                                        0 => 'Book',
+                                    ],
+                                    'snippet' => '<mark>Book</mark> title',
+                                ],
+                            ],
+                            'highlights' => [
+                                0 => [
+                                    'field' => 'title',
+                                    'matched_tokens' => [
+                                        0 => 'book',
+                                    ],
+                                    'snippet' => '<mark>Book</mark> title',
+                                ],
+                            ],
+                            'text_match' => 578730054645710969,
+                            'text_match_info' => [
+                                'best_field_score' => '1108057784320',
+                                'best_field_weight' => 15,
+                                'fields_matched' => 1,
+                                'score' => '578730054645710969',
+                                'tokens_matched' => 1,
+                            ],
+                        ],
+                    ],
+                    'out_of' => 42,
+                    'page' => 1,
+                    'request_params' => [
+                        'collection_name' => 'mybookcollection',
+                        'first_q' => 'book',
+                        'per_page' => 200,
+                        'q' => 'book',
+                    ],
+                    'search_cutoff' => false,
+                    'search_time_ms' => 3,
+                ],
+            ],
+        ]);
+
+        $search = new Search($client);
+        $searchResults = $search->multiSearch([new SearchQueryWithWithCollectionAdapter(new SearchQuery(q: 'book', queryBy: 'title'), 'mybookcollection')]);
+
+        $this->assertCount(1, $searchResults);
+        $this->assertCount(1, $searchResults[0]->getResults());
+        $this->assertCount(1, $searchResults[0]->getResults());
+
+        /** @var SearchResults $result */
+        $result = $searchResults[0]->getResults()[0];
+        $this->assertSame('117', $result['id']);
+    }
+}

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -61,6 +61,45 @@ class SearchResultTest extends \PHPUnit\Framework\TestCase
         'total_pages' => 12,
     ];
 
+    public const DATA_MULTISEARCH_UNION = [
+        'found' => 3,
+        'hits' => [
+            [
+                'collection' => 'books-2025-10-03-11-19-09',
+                'document' => [
+                    'title' => 'My book 1',
+                    'id' => '124',
+                ],
+                'highlight' => [],
+                'highlights' => [],
+            ],
+            [
+                'collection' => 'books-2025-10-03-11-19-09',
+                'document' => [
+                    'title' => 'my book 2',
+                    'id' => '125',
+                ],
+                'highlight' => [],
+                'highlights' => [],
+            ],
+        ],
+        'out_of' => 3,
+        'page' => 1,
+        'search_cutoff' => false,
+        'search_time_ms' => 0,
+        'union_request_params' => [
+            [
+                'collection' => 'books',
+                'q' => 'a',
+            ],
+            [
+                'collection' => 'posts',
+                'first_q' => '*',
+                'q' => 'b',
+            ],
+        ],
+    ];
+
     public function testFound(): void
     {
         $searchResults = $this->getSearchResult();
@@ -120,6 +159,13 @@ class SearchResultTest extends \PHPUnit\Framework\TestCase
         unset($data['request_params']);
         $searchResults = $this->getSearchResult($data);
         $this->assertEquals([], $searchResults->getRequestParameters());
+    }
+
+    public function testMultisearchUnion(): void
+    {
+        $data = self::DATA_MULTISEARCH_UNION;
+        $searchResults = $this->getSearchResult($data);
+        $this->assertEquals(self::DATA_MULTISEARCH_UNION['union_request_params'], $searchResults->getUnionRequestParameters());
     }
 
     public function testGetHighlightEmpty(): void


### PR DESCRIPTION
- [x] multi search for same collection + TEST multi search raw
- [ ] Union search (To be continued, especially naming and tests)
- [ ]  test multi search for same collection (SearchCollection  > multisearchRaw + multisearch)
- [ ] ~multi search for different collection + hydrated  + tests~ => Second mr
- [ ] Merge HydrateUnion with HydrateSearchResult and rename the class.